### PR TITLE
Fix bug when orphaning a level

### DIFF
--- a/program/program_result_level.py
+++ b/program/program_result_level.py
@@ -128,12 +128,12 @@ class program_result_level(orm.Model):
                 level.menu_id.write({'name': menu_title})
                 level.menu_id.action.write({'name': vals['menu_title']})
             if parent_id is not None:
-                depth = self.read(
-                    cr, user, parent_id, ['depth'], context=context
-                )['depth']
                 if parent_id is False:
-                    level.menu_id.action({'context': False})
+                    level.menu_id.action.write({'context': {}})
                 else:
+                    depth = self.read(
+                        cr, user, parent_id, ['depth'], context=context
+                    )['depth']
                     level.menu_id.action.write({
                         'context': {'default_parent_depth': depth}
                     })

--- a/program/tests/__init__.py
+++ b/program/tests/__init__.py
@@ -22,8 +22,10 @@
 
 from . import (
     test_program_result,
+    test_program_result_level,
 )
 
 checks = [
     test_program_result,
+    test_program_result_level,
 ]

--- a/program/tests/test_program_result.py
+++ b/program/tests/test_program_result.py
@@ -41,7 +41,6 @@ class test_program_result(TransactionCase):
         result_level_id = self.program_result_level_model.create(
             self.cr, self.uid, {
                 'name': 'Test Level',
-                'depth': 0,
             }, context=self.context)
         self.vals = {
             'name': 'Test Result',

--- a/program/tests/test_program_result_level.py
+++ b/program/tests/test_program_result_level.py
@@ -1,0 +1,94 @@
+# -*- encoding: utf-8 -*-
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2010 - 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from openerp.tests.common import TransactionCase
+
+
+class test_program_result_level(TransactionCase):
+
+    def setUp(self):
+        super(test_program_result_level, self).setUp()
+        # Clean up registries
+        self.registry('ir.model').clear_caches()
+        self.registry('ir.model.data').clear_caches()
+        # Get registries
+        self.user_model = self.registry("res.users")
+        self.program_result_level_model = self.registry("program.result.level")
+        # Get context
+        self.context = self.user_model.context_get(self.cr, self.uid)
+
+        self.result_level_1_id = self.program_result_level_model.create(
+            self.cr, self.uid, {
+                'name': 'Level 1',
+            }, context=self.context)
+        self.result_level_2_id = self.program_result_level_model.create(
+            self.cr, self.uid, {
+                'name': 'Level 2',
+                'parent_id': self.result_level_1_id,
+            }, context=self.context)
+        self.result_level_3_id = self.program_result_level_model.create(
+            self.cr, self.uid, {
+                'name': 'Level 2',
+                'parent_id': self.result_level_2_id,
+            }, context=self.context)
+
+    def test_depth(self):
+        result_level_1 = self.program_result_level_model.browse(
+            self.cr, self.uid, self.result_level_1_id, context=self.context
+        )
+        result_level_2 = self.program_result_level_model.browse(
+            self.cr, self.uid, self.result_level_2_id, context=self.context
+        )
+        result_level_3 = self.program_result_level_model.browse(
+            self.cr, self.uid, self.result_level_3_id, context=self.context
+        )
+        self.assertEqual(result_level_1.depth, 1)
+        self.assertEqual(result_level_2.depth, 2)
+        self.assertEqual(result_level_3.depth, 3)
+
+    def test_orphan(self):
+        # Clear the parent_id field, making this a top level
+        result_level_2 = self.program_result_level_model.browse(
+            self.cr, self.uid, self.result_level_2_id, context=self.context
+        )
+        result_level_2.write({'parent_id': False})
+        result_level_2.refresh()
+        self.assertEqual(result_level_2.depth, 1)
+
+    def test_reverse(self):
+        # Change parents by reversing the chain
+        result_level_1 = self.program_result_level_model.browse(
+            self.cr, self.uid, self.result_level_1_id, context=self.context
+        )
+        result_level_2 = self.program_result_level_model.browse(
+            self.cr, self.uid, self.result_level_2_id, context=self.context
+        )
+        result_level_3 = self.program_result_level_model.browse(
+            self.cr, self.uid, self.result_level_3_id, context=self.context
+        )
+        result_level_3.write({'parent_id': False})
+        result_level_3.refresh()
+        result_level_2.write({'parent_id': self.result_level_3_id})
+        result_level_2.refresh()
+        result_level_1.write({'parent_id': self.result_level_2_id})
+        result_level_1.refresh()
+        self.assertEqual(result_level_1.depth, 3)
+        self.assertEqual(result_level_2.depth, 2)
+        self.assertEqual(result_level_3.depth, 1)


### PR DESCRIPTION
Only read depth when there is a parent
Write an empty dict to menu context instead of clearning it as it can't be
null
Add tests to guard against regressions to level reorganisation
