### PR TITLE
[UPD] Allow to add document with add button

### DIFF
--- a/program_document/program_result_view.xml
+++ b/program_document/program_result_view.xml
@@ -14,7 +14,7 @@
                     string="Add"
                     class="oe_edit_only"/>
             <field name="document_ids">
-              <tree create="1">
+              <tree>
                 <field name="name" string="Name"/>
                 <field name="datas_fname" />
                 <field name="create_uid" />


### PR DESCRIPTION
Remove create option; it doesn't make sense because
the document is a field function and by default it is readonly
