### PR TITLE
[UPD]Disable create and create_edit option

### DIFF
--- a/program/__openerp__.py
+++ b/program/__openerp__.py
@@ -42,6 +42,7 @@ Contributors
     'license': 'AGPL-3',
     'depends': [
         'mail',
+        'web_m2x_options',
     ],
     'data': [
         'security/program_security.xml',

--- a/program/__openerp__.py
+++ b/program/__openerp__.py
@@ -42,7 +42,6 @@ Contributors
     'license': 'AGPL-3',
     'depends': [
         'mail',
-        'web_m2x_options',
     ],
     'data': [
         'security/program_security.xml',

--- a/program_budget/program_result_country_view.xml
+++ b/program_budget/program_result_country_view.xml
@@ -8,9 +8,9 @@
       <field name="arch" type="xml">
 
         <tree string="Result Countries" version="7.0" editable="bottom">
-          <field name="name" />
+          <field name="name" options="{'create': false, 'create_edit': false}"/>
           <field name="code" />
-          <field name="role" />
+          <field name="role" options="{'create': false, 'create_edit': false}"/>
         </tree>
 
       </field>

--- a/program_budget_team/program_result_team_partner_view.xml
+++ b/program_budget_team/program_result_team_partner_view.xml
@@ -28,6 +28,7 @@
 
         <field name="currency_id" position="attributes">
           <attribute name="invisible">0</attribute>
+          <attribute name="options">{'create': false, 'create_edit': false}</attribute>
         </field>
 
         <field name="amount" position="attributes">

--- a/program_team/program_result_team_partner_view.xml
+++ b/program_team/program_result_team_partner_view.xml
@@ -9,9 +9,9 @@
 
         <tree string="Team Roles" version="7.0" editable="bottom">
 
-          <field name="partner_id" />
+          <field name="partner_id" options="{'create': false, 'create_edit': false}"/>
           <field name="country_id" readonly="True"/>
-          <field name="type_id" widget="many2many_tags"/>
+          <field name="type_id" widget="many2many_tags" options="{'create': false, 'create_edit': false}"/>
 
         </tree>
 

--- a/program_team/program_result_view.xml
+++ b/program_team/program_result_view.xml
@@ -20,21 +20,29 @@
             <group colspan="4" col="2">
               <field name="team_department_ids">
                 <tree editable="bottom">
-                  <field name="department_id"/>
+                  <field name="department_id"
+                         options="{'create': false, 'create_edit': false}"/>
                     <button name="action_department_form_view"
                             type="object"
                             icon="gtk-open"/>
-                  <field name="role_id" domain="[('is_department', '=', True)]" context="{'default_is_department': True}"/>
+                  <field name="role_id"
+                         domain="[('is_department', '=', True)]"
+                         context="{'default_is_department': True}"
+                         options="{'create': false, 'create_edit': false}"/>
                 </tree>
               </field>
 
               <field name="team_member_ids">
                 <tree editable="bottom">
-                  <field name="employee_id"/>
+                  <field name="employee_id"
+                         options="{'create': false, 'create_edit': false}"/>
                   <button name="action_member_form_view"
                           type="object"
                           icon="gtk-open"/>
-                  <field name="role_id" domain="[('is_employee', '=', True)]"  context="{'default_is_employee': True}"/>
+                  <field name="role_id"
+                         domain="[('is_employee', '=', True)]"
+                         context="{'default_is_employee': True}"
+                         options="{'create': false, 'create_edit': false}"/>
                 </tree>
               </field>
 


### PR DESCRIPTION
Don't allow 'create' and 'create_edit' for these fields:
- Targets tab: name and role fields
- Team tab: department_id, role and employee_id fields
- Partners tab: partner_id, type_id and currency-id fields
